### PR TITLE
Remove contact and location from customer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,3 @@ DEPENDENCIES
   uuid
   virtus
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.6

--- a/config/subscribers/customer.rb
+++ b/config/subscribers/customer.rb
@@ -1,8 +1,6 @@
 Promiscuous.define do
   subscribe :customer do
     attributes :entity_id,
-               :contact_id,
-               :location_id,
                :parent_customer_id,
                :salesperson_id,
                :deleted_at,

--- a/config/subscribers/vendor.rb
+++ b/config/subscribers/vendor.rb
@@ -1,8 +1,6 @@
 Promiscuous.define do
   subscribe :vendor do
     attributes :entity_id,
-               :contact_id,
-               :location_id,
                :deleted_at,
                :is_active,
                :uuid

--- a/db/migrate/20151021231613_remove_contact_id_and_location_id_from_customers.rb
+++ b/db/migrate/20151021231613_remove_contact_id_and_location_id_from_customers.rb
@@ -1,0 +1,6 @@
+class RemoveContactIdAndLocationIdFromCustomers < ActiveRecord::Migration
+  def change
+    remove_column :customers, :contact_id
+    remove_column :customers, :location_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150826201759) do
+ActiveRecord::Schema.define(version: 20151021231613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,8 +38,6 @@ ActiveRecord::Schema.define(version: 20150826201759) do
   end
 
   create_table "customers", force: :cascade do |t|
-    t.integer  "contact_id"
-    t.integer  "location_id"
     t.integer  "entity_id",                                  null: false
     t.integer  "parent_customer_id"
     t.integer  "bill_to_location_id",                        null: false

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Customer, type: :model do
   subject { build(:customer, entity: build(:entity)) }
 
   it { is_expected.to belong_to(:bill_to_location).class_name(Location) }
-  it { is_expected.to belong_to(:contact) }
   it { is_expected.to belong_to(:entity) }
-  it { is_expected.to belong_to(:location) }
   it { is_expected.to belong_to(:parent_customer) }
   it { is_expected.to belong_to(:salesperson) }
   it { is_expected.to belong_to(:ship_to_location).class_name(Location) }


### PR DESCRIPTION
  Remove the contact and location from the customer model to
  remain inline with changes to Entity Master.

  Closes #41